### PR TITLE
Allow koriym/semantic-logger 0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "ray/di": "^2.18",
         "ray/input-query": "^v1.0",
-        "koriym/semantic-logger": "^0.8"
+        "koriym/semantic-logger": "^0.8 || ^0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbc5e2ba2a05d8a9a1e8db861df3f179",
+    "content-hash": "74f63a1d38919b85a18b8f276762fde4",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -137,16 +137,16 @@
         },
         {
             "name": "koriym/semantic-logger",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/koriym/Koriym.SemanticLogger.git",
-                "reference": "11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d"
+                "reference": "5e427285bad04169e6d33162b2afd2611b3a52c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koriym/Koriym.SemanticLogger/zipball/11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d",
-                "reference": "11ceb9e6d7a9e4723736f66bce9be78eb8a5b94d",
+                "url": "https://api.github.com/repos/koriym/Koriym.SemanticLogger/zipball/5e427285bad04169e6d33162b2afd2611b3a52c1",
+                "reference": "5e427285bad04169e6d33162b2afd2611b3a52c1",
                 "shasum": ""
             },
             "require": {
@@ -159,7 +159,7 @@
             },
             "bin": [
                 "bin/validate-semantic-log.php",
-                "bin/stree"
+                "src-stree/bin/stree"
             ],
             "type": "library",
             "extra": {
@@ -170,7 +170,8 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Koriym\\SemanticLogger\\": "src/"
+                    "Koriym\\SemanticLogger\\": "src/",
+                    "Koriym\\SemanticLogger\\Stree\\": "src-stree/src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -186,9 +187,9 @@
             "description": "Type-safe structured logging with schema validation and meaningful context",
             "support": {
                 "issues": "https://github.com/koriym/Koriym.SemanticLogger/issues",
-                "source": "https://github.com/koriym/Koriym.SemanticLogger/tree/0.8.0"
+                "source": "https://github.com/koriym/Koriym.SemanticLogger/tree/0.9.0"
             },
-            "time": "2026-04-24T08:34:32+00:00"
+            "time": "2026-08-12T12:58:19+00:00"
         },
         {
             "name": "marc-mabe/php-enum",

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -166,7 +166,9 @@ final class LoggerTest extends TestCase
 
         $this->assertSame('becoming_open', $openData['type']);
         $this->assertSame(TestInput::class, $openData['context']['input']);
-        $this->assertSame(['data' => 'data'], $openData['context']['prop']);
+        // 0.9 freezes the context, so a map arrives as an object; 0.8 kept it an array.
+        // The cast reads the same under both, which is what the constraint allows.
+        $this->assertSame(['data' => 'data'], (array) $openData['context']['prop']);
     }
 
     public function testCloseChainLogsSuccessExit(): void


### PR DESCRIPTION
`^0.8` reads as `<0.9`, so an application cannot install this framework beside a package that requires semantic-logger 0.9. BEAR.QueryRepository `1.x` now does, and the two conflict at resolution time — found while installing it into BeMart.

Nothing here needs the old contract:

- this framework only calls `open()` and `close()`, whose signatures are identical in 0.8 and 0.9
- it references three symbols, all present in 0.9: `AbstractContext`, `SemanticLogger`, `SemanticLoggerInterface`
- the exception hierarchy 0.9 removed was never caught here, and `flush()` is never called from this package

One test needed a change. 0.9 freezes a recorded context, so a map comes back from `toArray()` as an object where 0.8 handed back an array. `LoggerTest::testOpenChainLogsInputProps` was the only place that looked; the cast it now does reads the same under both versions.

Verified: 252 tests green on 0.9.0, then again after pinning 0.8.0 — both branches of the constraint hold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with frozen logging context objects while preserving expected logged data.

* **Chores**
  * Expanded support for newer compatible versions of the semantic logging component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->